### PR TITLE
(fix) fixes loading pages when not signed in

### DIFF
--- a/public/client/app/app.routes.js
+++ b/public/client/app/app.routes.js
@@ -62,8 +62,6 @@ angular.module('booklist', [
         $rootScope.signedIn = false;
         $location.path('/');
       }
-    } else {
-      $location.path('/');
     }
   });
 }]);


### PR DESCRIPTION
Was forcing location path to be '/' whenever there was no token present.
